### PR TITLE
feat: add Setmore booking button

### DIFF
--- a/app/[locale]/(site)/contact/page.tsx
+++ b/app/[locale]/(site)/contact/page.tsx
@@ -1,5 +1,6 @@
 
 import { getDictionary, type Locale } from "@/dictionaries";
+import SetmoreButton from "@/components/SetmoreButton";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: Locale }> }) {
   const { locale } = await params;
@@ -19,6 +20,10 @@ export default async function ContactPage({ params }: { params: Promise<{ locale
   return (
     <div className="mx-auto max-w-6xl px-4 py-12">
       <h1 className="text-3xl font-semibold text-ink mb-6">{dict.contact.title}</h1>
+
+      <div className="mb-6">
+        <SetmoreButton label={dict.home.heroCta} />
+      </div>
 
       <div className="grid gap-8 md:grid-cols-2 items-start">
         <form className="space-y-4">

--- a/app/[locale]/(site)/page.tsx
+++ b/app/[locale]/(site)/page.tsx
@@ -1,5 +1,6 @@
 
 import Link from "next/link";
+import SetmoreButton from "@/components/SetmoreButton";
 import { getDictionary, type Locale } from "@/dictionaries";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: Locale }> }) {
@@ -27,9 +28,7 @@ export default async function Home({ params }: { params: Promise<{ locale: Local
           <h1 className="text-3xl md:text-5xl font-semibold text-ink">{dict.home.heroHeading}</h1>
           <p className="mt-4 text-lg text-slate-700">{dict.home.heroText}</p>
           <div className="mt-8">
-            <Link href={`/${locale}/contact`} className="inline-block px-6 py-3 rounded-xl2 border border-gold text-gold hover:bg-gold hover:text-white transition shadow-soft">
-              {dict.home.heroCta}
-            </Link>
+            <SetmoreButton label={dict.home.heroCta} />
           </div>
         </div>
       </section>

--- a/app/[locale]/(site)/services/infant-massage/page.tsx
+++ b/app/[locale]/(site)/services/infant-massage/page.tsx
@@ -1,5 +1,6 @@
 
 import { getDictionary, type Locale } from "@/dictionaries";
+import SetmoreButton from "@/components/SetmoreButton";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: Locale }> }) {
   const { locale } = await params;
@@ -23,7 +24,7 @@ export default async function InfantPage({ params }: { params: Promise<{ locale:
         <div>
           <h1 className="text-3xl font-semibold text-ink">{t.title}</h1>
           <p className="mt-4 text-lg text-slate-700">{t.lead}</p>
-          <a href={`/${locale}/contact`} className="mt-6 inline-block px-5 py-3 rounded-xl2 border border-gold text-gold hover:bg-gold hover:text-white transition">{t.cta}</a>
+            <SetmoreButton label={t.cta} />
         </div>
         <div className="rounded-2xl overflow-hidden border shadow-soft">
           <img src="/images/infant-massage.webp" alt="" className="w-full h-full object-cover" />

--- a/app/[locale]/(site)/services/naturopathy/page.tsx
+++ b/app/[locale]/(site)/services/naturopathy/page.tsx
@@ -1,5 +1,6 @@
 
 import { getDictionary, type Locale } from "@/dictionaries";
+import SetmoreButton from "@/components/SetmoreButton";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: Locale }> }) {
   const { locale } = await params;
@@ -23,7 +24,7 @@ export default async function NaturopathyPage({ params }: { params: Promise<{ lo
         <div>
           <h1 className="text-3xl font-semibold text-ink">{t.title}</h1>
           <p className="mt-4 text-lg text-slate-700">{t.lead}</p>
-          <a href={`/${locale}/contact`} className="mt-6 inline-block px-5 py-3 rounded-xl2 border border-gold text-gold hover:bg-gold hover:text-white transition">{t.cta}</a>
+            <SetmoreButton label={t.cta} />
         </div>
         <div className="rounded-2xl overflow-hidden border shadow-soft">
           <img src="/images/naturopathy.webp" alt="" className="w-full h-full object-cover" />

--- a/app/[locale]/(site)/services/shiatsu/page.tsx
+++ b/app/[locale]/(site)/services/shiatsu/page.tsx
@@ -1,5 +1,6 @@
 
 import { getDictionary, type Locale } from "@/dictionaries";
+import SetmoreButton from "@/components/SetmoreButton";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: Locale }> }) {
   const { locale } = await params;
@@ -23,7 +24,7 @@ export default async function ShiatsuPage({ params }: { params: Promise<{ locale
         <div>
           <h1 className="text-3xl font-semibold text-ink">{t.title}</h1>
           <p className="mt-4 text-lg text-slate-700">{t.lead}</p>
-          <a href={`/${locale}/contact`} className="mt-6 inline-block px-5 py-3 rounded-xl2 border border-gold text-gold hover:bg-gold hover:text-white transition">{t.cta}</a>
+            <SetmoreButton label={t.cta} />
         </div>
         <div className="rounded-2xl overflow-hidden border shadow-soft">
           <img src="/images/shiatsu.webp" alt="" className="w-full h-full object-cover" />

--- a/components/SetmoreButton.tsx
+++ b/components/SetmoreButton.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect } from "react";
+
+type Props = {
+  label?: string;
+  className?: string;
+  id?: string;
+};
+
+export default function SetmoreButton({
+  label = "Prenota un appuntamento",
+  className = "inline-block px-6 py-3 rounded-xl2 border border-gold text-gold hover:bg-gold hover:text-white transition",
+  id = "Setmore_button_iframe",
+}: Props) {
+  const bookingUrl = process.env.NEXT_PUBLIC_SETMORE_URL;
+
+  useEffect(() => {
+    // Carica lo script Setmore una sola volta in tutta l'app
+    const scriptId = "setmore-widget-js";
+    if (document.getElementById(scriptId)) return;
+    const s = document.createElement("script");
+    s.id = scriptId;
+    s.src = "https://my.setmore.com/webapp/js/widget.js";
+    s.async = true;
+    document.body.appendChild(s);
+  }, []);
+
+  if (!bookingUrl) {
+    // fallback di sicurezza: non rompiamo l'UI se manca l'ENV
+    return (
+      <a
+        href="#"
+        aria-disabled="true"
+        className={`${className} opacity-60 pointer-events-none`}
+        title="Configura NEXT_PUBLIC_SETMORE_URL"
+      >
+        {label}
+      </a>
+    );
+  }
+
+  // L’ancora con id specifico fa aprire il popup di Setmore
+  return (
+    <a id={id} href={bookingUrl} className={className} rel="nofollow">
+      {label}
+    </a>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add reusable `SetmoreButton` that loads widget script and handles missing URL
- use `SetmoreButton` on homepage hero, service pages, and contact page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898a3f0f6dc8330a5768ccd30693ef3