### PR TITLE
Reposition booking buttons and add service detail overlays

### DIFF
--- a/app/[locale]/(site)/page.tsx
+++ b/app/[locale]/(site)/page.tsx
@@ -1,6 +1,5 @@
 
 import Link from "next/link";
-import SetmoreButton from "@/components/SetmoreButton";
 import { getDictionary, type Locale } from "@/dictionaries";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: Locale }> }) {
@@ -27,9 +26,6 @@ export default async function Home({ params }: { params: Promise<{ locale: Local
            <img src="/images/Logo-colours.png" alt="San Bao" className="mx-auto h-28 w-auto mb-6" />
           <h1 className="text-3xl md:text-5xl font-semibold text-ink">{dict.home.heroHeading}</h1>
           <p className="mt-4 text-lg text-slate-700">{dict.home.heroText}</p>
-          <div className="mt-8">
-            <SetmoreButton alt={dict.home.heroCta} />
-          </div>
         </div>
       </section>
 

--- a/app/[locale]/(site)/services/face-massage/more/page.tsx
+++ b/app/[locale]/(site)/services/face-massage/more/page.tsx
@@ -1,0 +1,15 @@
+import { getDictionary, type Locale } from "@/dictionaries";
+
+export default async function FaceMassageMorePage({ params }: { params: Promise<{ locale: Locale }> }) {
+  const { locale } = await params;
+  const dict = await getDictionary(locale);
+
+  return (
+    <div className="fixed inset-0 bg-white/90 p-8 overflow-y-auto">
+      <div className="mx-auto max-w-3xl">
+        <h1 className="text-3xl font-semibold text-ink mb-4">{dict.nav.faceMassage}</h1>
+        <p className="text-lg text-slate-700">{dict.placeholder}</p>
+      </div>
+    </div>
+  );
+}

--- a/app/[locale]/(site)/services/face-massage/page.tsx
+++ b/app/[locale]/(site)/services/face-massage/page.tsx
@@ -1,12 +1,24 @@
 import { getDictionary, type Locale } from "@/dictionaries";
+import SetmoreButton from "@/components/SetmoreButton";
+import Link from "next/link";
 
 export default async function FaceMassagePage({ params }: { params: Promise<{ locale: Locale }> }) {
   const { locale } = await params;
   const dict = await getDictionary(locale);
+  const cta = dict.services.naturopathy.cta;
   return (
     <div className="mx-auto max-w-6xl px-4 py-12">
       <h1 className="text-3xl font-semibold text-ink">{dict.nav.faceMassage}</h1>
       <p className="mt-4 text-lg text-slate-700">{dict.placeholder}</p>
+      <div className="mt-8 flex gap-4">
+        <SetmoreButton alt={cta} />
+        <Link
+          href={`/${locale}/services/face-massage/more`}
+          className="inline-block px-5 py-3 rounded-xl2 border border-gold text-gold hover:bg-gold hover:text-white transition"
+        >
+          {dict.more}
+        </Link>
+      </div>
     </div>
   );
 }

--- a/app/[locale]/(site)/services/infant-massage/more/page.tsx
+++ b/app/[locale]/(site)/services/infant-massage/more/page.tsx
@@ -1,0 +1,16 @@
+import { getDictionary, type Locale } from "@/dictionaries";
+
+export default async function InfantMorePage({ params }: { params: Promise<{ locale: Locale }> }) {
+  const { locale } = await params;
+  const dict = await getDictionary(locale);
+  const t = dict.services.infant;
+
+  return (
+    <div className="fixed inset-0 bg-white/90 p-8 overflow-y-auto">
+      <div className="mx-auto max-w-3xl">
+        <h1 className="text-3xl font-semibold text-ink mb-4">{t.title}</h1>
+        <p className="text-lg text-slate-700">{dict.placeholder}</p>
+      </div>
+    </div>
+  );
+}

--- a/app/[locale]/(site)/services/infant-massage/page.tsx
+++ b/app/[locale]/(site)/services/infant-massage/page.tsx
@@ -1,6 +1,7 @@
 
 import { getDictionary, type Locale } from "@/dictionaries";
 import SetmoreButton from "@/components/SetmoreButton";
+import Link from "next/link";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: Locale }> }) {
   const { locale } = await params;
@@ -24,7 +25,15 @@ export default async function InfantPage({ params }: { params: Promise<{ locale:
         <div>
           <h1 className="text-3xl font-semibold text-ink">{t.title}</h1>
           <p className="mt-4 text-lg text-slate-700">{t.lead}</p>
+          <div className="mt-8 flex gap-4">
             <SetmoreButton alt={t.cta} />
+            <Link
+              href={`/${locale}/services/infant-massage/more`}
+              className="inline-block px-5 py-3 rounded-xl2 border border-gold text-gold hover:bg-gold hover:text-white transition"
+            >
+              {dict.more}
+            </Link>
+          </div>
         </div>
         <div className="rounded-2xl overflow-hidden border shadow-soft">
           <img src="/images/infant-massage.webp" alt="" className="w-full h-full object-cover" />

--- a/app/[locale]/(site)/services/naturopathy/more/page.tsx
+++ b/app/[locale]/(site)/services/naturopathy/more/page.tsx
@@ -1,0 +1,16 @@
+import { getDictionary, type Locale } from "@/dictionaries";
+
+export default async function NaturopathyMorePage({ params }: { params: Promise<{ locale: Locale }> }) {
+  const { locale } = await params;
+  const dict = await getDictionary(locale);
+  const t = dict.services.naturopathy;
+
+  return (
+    <div className="fixed inset-0 bg-white/90 p-8 overflow-y-auto">
+      <div className="mx-auto max-w-3xl">
+        <h1 className="text-3xl font-semibold text-ink mb-4">{t.title}</h1>
+        <p className="text-lg text-slate-700">{dict.placeholder}</p>
+      </div>
+    </div>
+  );
+}

--- a/app/[locale]/(site)/services/naturopathy/page.tsx
+++ b/app/[locale]/(site)/services/naturopathy/page.tsx
@@ -1,6 +1,7 @@
 
 import { getDictionary, type Locale } from "@/dictionaries";
 import SetmoreButton from "@/components/SetmoreButton";
+import Link from "next/link";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: Locale }> }) {
   const { locale } = await params;
@@ -24,7 +25,15 @@ export default async function NaturopathyPage({ params }: { params: Promise<{ lo
         <div>
           <h1 className="text-3xl font-semibold text-ink">{t.title}</h1>
           <p className="mt-4 text-lg text-slate-700">{t.lead}</p>
+          <div className="mt-8 flex gap-4">
             <SetmoreButton alt={t.cta} />
+            <Link
+              href={`/${locale}/services/naturopathy/more`}
+              className="inline-block px-5 py-3 rounded-xl2 border border-gold text-gold hover:bg-gold hover:text-white transition"
+            >
+              {dict.more}
+            </Link>
+          </div>
         </div>
         <div className="rounded-2xl overflow-hidden border shadow-soft">
           <img src="/images/naturopathy.webp" alt="" className="w-full h-full object-cover" />

--- a/app/[locale]/(site)/services/qi-nei-zang/more/page.tsx
+++ b/app/[locale]/(site)/services/qi-nei-zang/more/page.tsx
@@ -1,0 +1,15 @@
+import { getDictionary, type Locale } from "@/dictionaries";
+
+export default async function QiNeiZangMorePage({ params }: { params: Promise<{ locale: Locale }> }) {
+  const { locale } = await params;
+  const dict = await getDictionary(locale);
+
+  return (
+    <div className="fixed inset-0 bg-white/90 p-8 overflow-y-auto">
+      <div className="mx-auto max-w-3xl">
+        <h1 className="text-3xl font-semibold text-ink mb-4">{dict.nav.qiNeiZang}</h1>
+        <p className="text-lg text-slate-700">{dict.placeholder}</p>
+      </div>
+    </div>
+  );
+}

--- a/app/[locale]/(site)/services/qi-nei-zang/page.tsx
+++ b/app/[locale]/(site)/services/qi-nei-zang/page.tsx
@@ -1,12 +1,24 @@
 import { getDictionary, type Locale } from "@/dictionaries";
+import SetmoreButton from "@/components/SetmoreButton";
+import Link from "next/link";
 
 export default async function QiNeiZangPage({ params }: { params: Promise<{ locale: Locale }> }) {
   const { locale } = await params;
   const dict = await getDictionary(locale);
+  const cta = dict.services.naturopathy.cta;
   return (
     <div className="mx-auto max-w-6xl px-4 py-12">
       <h1 className="text-3xl font-semibold text-ink">{dict.nav.qiNeiZang}</h1>
       <p className="mt-4 text-lg text-slate-700">{dict.placeholder}</p>
+      <div className="mt-8 flex gap-4">
+        <SetmoreButton alt={cta} />
+        <Link
+          href={`/${locale}/services/qi-nei-zang/more`}
+          className="inline-block px-5 py-3 rounded-xl2 border border-gold text-gold hover:bg-gold hover:text-white transition"
+        >
+          {dict.more}
+        </Link>
+      </div>
     </div>
   );
 }

--- a/app/[locale]/(site)/services/shiatsu/more/page.tsx
+++ b/app/[locale]/(site)/services/shiatsu/more/page.tsx
@@ -1,0 +1,16 @@
+import { getDictionary, type Locale } from "@/dictionaries";
+
+export default async function ShiatsuMorePage({ params }: { params: Promise<{ locale: Locale }> }) {
+  const { locale } = await params;
+  const dict = await getDictionary(locale);
+  const t = dict.services.shiatsu;
+
+  return (
+    <div className="fixed inset-0 bg-white/90 p-8 overflow-y-auto">
+      <div className="mx-auto max-w-3xl">
+        <h1 className="text-3xl font-semibold text-ink mb-4">{t.title}</h1>
+        <p className="text-lg text-slate-700">{dict.placeholder}</p>
+      </div>
+    </div>
+  );
+}

--- a/app/[locale]/(site)/services/shiatsu/page.tsx
+++ b/app/[locale]/(site)/services/shiatsu/page.tsx
@@ -1,6 +1,7 @@
 
 import { getDictionary, type Locale } from "@/dictionaries";
 import SetmoreButton from "@/components/SetmoreButton";
+import Link from "next/link";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: Locale }> }) {
   const { locale } = await params;
@@ -24,7 +25,15 @@ export default async function ShiatsuPage({ params }: { params: Promise<{ locale
         <div>
           <h1 className="text-3xl font-semibold text-ink">{t.title}</h1>
           <p className="mt-4 text-lg text-slate-700">{t.lead}</p>
+          <div className="mt-8 flex gap-4">
             <SetmoreButton alt={t.cta} />
+            <Link
+              href={`/${locale}/services/shiatsu/more`}
+              className="inline-block px-5 py-3 rounded-xl2 border border-gold text-gold hover:bg-gold hover:text-white transition"
+            >
+              {dict.more}
+            </Link>
+          </div>
         </div>
         <div className="rounded-2xl overflow-hidden border shadow-soft">
           <img src="/images/shiatsu.webp" alt="" className="w-full h-full object-cover" />

--- a/dictionaries/en.ts
+++ b/dictionaries/en.ts
@@ -52,6 +52,7 @@ export const dictionary = {
       cta: "Book now"
     }
   },
+  more: "More",
   placeholder: "Content coming soon.",
   disclaimer: "UNDER NO CIRCUMSTANCES DOES THIS SUPPORT REPLACE MEDICAL ADVICE OR FOLLOW-UP."
 };

--- a/dictionaries/es.ts
+++ b/dictionaries/es.ts
@@ -52,6 +52,7 @@ export const dictionary = {
       cta: "Reservar ahora"
     }
   },
+  more: "Más",
   placeholder: "Contenido próximamente.",
   disclaimer: "EN NINGÚN CASO ESTE ACOMPAÑAMIENTO SUSTITUYE UN CONSEJO / SEGUIMIENTO MÉDICO."
 };

--- a/dictionaries/fr.ts
+++ b/dictionaries/fr.ts
@@ -52,6 +52,7 @@ export const dictionary = {
       cta: "Prendre rendez‑vous"
     }
   },
+  more: "Plus",
   placeholder: "Contenu à venir.",
   disclaimer: "EN AUCUN CAS, CET ACCOMPAGNEMENT NE REMPLACE UN AVIS / SUIVI MEDICAL"
 };

--- a/dictionaries/it.ts
+++ b/dictionaries/it.ts
@@ -52,6 +52,7 @@ export const dictionary = {
       cta: "Prenota ora"
     }
   },
+  more: "Più",
   placeholder: "Contenuto in arrivo.",
   disclaimer: "IN NESSUN CASO QUESTO ACCOMPAGNAMENTO SOSTITUISCE UN PARERE / SEGUITO MEDICO."
 };

--- a/dictionaries/nl.ts
+++ b/dictionaries/nl.ts
@@ -52,6 +52,7 @@ export const dictionary = {
       cta: "Boek nu"
     }
   },
+  more: "Meer",
   placeholder: "Inhoud binnenkort beschikbaar.",
   disclaimer: "IN GEEN GEVAL VERVANGT DEZE BEGELEIDING EEN MEDISCH ADVIES / OPVOLGING."
 };


### PR DESCRIPTION
## Summary
- remove Setmore booking button from homepage hero
- reposition booking button and add new More link on service pages
- include placeholder overlay pages for each service with placeholder content
- add `more` translation key across dictionaries

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899eece4ba883309d296e34efdce32b