### PR TITLE
Add overlay close buttons and update Shiatsu content

### DIFF
--- a/app/[locale]/(site)/services/face-massage/more/page.tsx
+++ b/app/[locale]/(site)/services/face-massage/more/page.tsx
@@ -1,4 +1,5 @@
 import { getDictionary, type Locale } from "@/dictionaries";
+import Link from "next/link";
 
 export default async function FaceMassageMorePage({ params }: { params: Promise<{ locale: Locale }> }) {
   const { locale } = await params;
@@ -6,6 +7,12 @@ export default async function FaceMassageMorePage({ params }: { params: Promise<
 
   return (
     <div className="fixed inset-0 bg-white/90 p-8 overflow-y-auto">
+      <Link
+        href={`/${locale}/services/face-massage`}
+        className="absolute top-8 right-8 inline-block px-5 py-3 rounded-xl2 border border-gold text-gold hover:bg-gold hover:text-white transition"
+      >
+        {dict.close}
+      </Link>
       <div className="mx-auto max-w-3xl">
         <h1 className="text-3xl font-semibold text-ink mb-4">{dict.nav.faceMassage}</h1>
         <p className="text-lg text-slate-700">{dict.placeholder}</p>

--- a/app/[locale]/(site)/services/infant-massage/more/page.tsx
+++ b/app/[locale]/(site)/services/infant-massage/more/page.tsx
@@ -1,4 +1,5 @@
 import { getDictionary, type Locale } from "@/dictionaries";
+import Link from "next/link";
 
 export default async function InfantMorePage({ params }: { params: Promise<{ locale: Locale }> }) {
   const { locale } = await params;
@@ -7,6 +8,12 @@ export default async function InfantMorePage({ params }: { params: Promise<{ loc
 
   return (
     <div className="fixed inset-0 bg-white/90 p-8 overflow-y-auto">
+      <Link
+        href={`/${locale}/services/infant-massage`}
+        className="absolute top-8 right-8 inline-block px-5 py-3 rounded-xl2 border border-gold text-gold hover:bg-gold hover:text-white transition"
+      >
+        {dict.close}
+      </Link>
       <div className="mx-auto max-w-3xl">
         <h1 className="text-3xl font-semibold text-ink mb-4">{t.title}</h1>
         <p className="text-lg text-slate-700">{dict.placeholder}</p>

--- a/app/[locale]/(site)/services/naturopathy/more/page.tsx
+++ b/app/[locale]/(site)/services/naturopathy/more/page.tsx
@@ -1,4 +1,5 @@
 import { getDictionary, type Locale } from "@/dictionaries";
+import Link from "next/link";
 
 export default async function NaturopathyMorePage({ params }: { params: Promise<{ locale: Locale }> }) {
   const { locale } = await params;
@@ -7,6 +8,12 @@ export default async function NaturopathyMorePage({ params }: { params: Promise<
 
   return (
     <div className="fixed inset-0 bg-white/90 p-8 overflow-y-auto">
+      <Link
+        href={`/${locale}/services/naturopathy`}
+        className="absolute top-8 right-8 inline-block px-5 py-3 rounded-xl2 border border-gold text-gold hover:bg-gold hover:text-white transition"
+      >
+        {dict.close}
+      </Link>
       <div className="mx-auto max-w-3xl">
         <h1 className="text-3xl font-semibold text-ink mb-4">{t.title}</h1>
         <p className="text-lg text-slate-700">{dict.placeholder}</p>

--- a/app/[locale]/(site)/services/qi-nei-zang/more/page.tsx
+++ b/app/[locale]/(site)/services/qi-nei-zang/more/page.tsx
@@ -1,4 +1,5 @@
 import { getDictionary, type Locale } from "@/dictionaries";
+import Link from "next/link";
 
 export default async function QiNeiZangMorePage({ params }: { params: Promise<{ locale: Locale }> }) {
   const { locale } = await params;
@@ -6,6 +7,12 @@ export default async function QiNeiZangMorePage({ params }: { params: Promise<{ 
 
   return (
     <div className="fixed inset-0 bg-white/90 p-8 overflow-y-auto">
+      <Link
+        href={`/${locale}/services/qi-nei-zang`}
+        className="absolute top-8 right-8 inline-block px-5 py-3 rounded-xl2 border border-gold text-gold hover:bg-gold hover:text-white transition"
+      >
+        {dict.close}
+      </Link>
       <div className="mx-auto max-w-3xl">
         <h1 className="text-3xl font-semibold text-ink mb-4">{dict.nav.qiNeiZang}</h1>
         <p className="text-lg text-slate-700">{dict.placeholder}</p>

--- a/app/[locale]/(site)/services/shiatsu/more/page.tsx
+++ b/app/[locale]/(site)/services/shiatsu/more/page.tsx
@@ -1,4 +1,5 @@
 import { getDictionary, type Locale } from "@/dictionaries";
+import Link from "next/link";
 
 export default async function ShiatsuMorePage({ params }: { params: Promise<{ locale: Locale }> }) {
   const { locale } = await params;
@@ -7,6 +8,12 @@ export default async function ShiatsuMorePage({ params }: { params: Promise<{ lo
 
   return (
     <div className="fixed inset-0 bg-white/90 p-8 overflow-y-auto">
+      <Link
+        href={`/${locale}/services/shiatsu`}
+        className="absolute top-8 right-8 inline-block px-5 py-3 rounded-xl2 border border-gold text-gold hover:bg-gold hover:text-white transition"
+      >
+        {dict.close}
+      </Link>
       <div className="mx-auto max-w-3xl">
         <h1 className="text-3xl font-semibold text-ink mb-4">{t.title}</h1>
         <p className="text-lg text-slate-700">{dict.placeholder}</p>

--- a/components/SetmoreButton.tsx
+++ b/components/SetmoreButton.tsx
@@ -28,12 +28,12 @@ export default function SetmoreButton({
   }, []);
 
   return (
-    <a id={id} href={bookingUrl} style={{ float: "none" }}>
-      <img
-        src="https://assets.setmore.com/setmore/images/2.0/Settings/book-now-black.svg"
-        alt={alt}
-        style={{ border: "none" }}
-      />
+    <a
+      id={id}
+      href={bookingUrl}
+      className="inline-block px-5 py-3 rounded-xl2 border border-gold text-gold hover:bg-gold hover:text-white transition"
+    >
+      {alt}
     </a>
   );
 }

--- a/dictionaries/en.ts
+++ b/dictionaries/en.ts
@@ -6,7 +6,7 @@ export const dictionary = {
     home: { title: "San Bao – Shiatsu & Naturopathy", description: "Restore balance and breath with manual treatments and natural approaches." },
     contact: { title: "Contact – San Bao", description: "Book an appointment or ask for information. We are in Brussels." },
     services: {
-      shiatsu: { title: "Shiatsu & Qi Nei Zang – San Bao", description: "Acupressure and visceral work to harmonise energy (Qi)." },
+      shiatsu: { title: "Shiatsu – San Bao", description: "Acupressure to harmonise energy (Qi)." },
       naturopathy: { title: "Naturopathy – San Bao", description: "Personalised natural guidance for overall wellbeing." },
       infant: { title: "Infant massage – San Bao", description: "Gentle touch that supports calm, sleep and harmonious growth." }
     }
@@ -36,11 +36,11 @@ export const dictionary = {
   },
   contact: { title:"Contact", name:"Name", email:"Email", message:"Message", send:"Send", whatsapp:"Message us on WhatsApp" },
   services: {
-    shiatsu: {
-      title: "Shiatsu & Qi Nei Zang",
-      lead: "Acupressure along the meridians and Qi Nei Zang (visceral work) to release tension and support the flow of Qi.",
-      cta: "Book now"
-    },
+      shiatsu: {
+        title: "Shiatsu",
+        lead: "Acupressure along the meridians to release tension and support the flow of Qi.",
+        cta: "Book now"
+      },
     naturopathy: {
       title: "Naturopathy",
       lead: "Personalised natural guidance: nutrition, lifestyle and gentle techniques for overall wellbeing.",
@@ -52,7 +52,8 @@ export const dictionary = {
       cta: "Book now"
     }
   },
-  more: "More",
-  placeholder: "Content coming soon.",
+    more: "More",
+    close: "Close",
+    placeholder: "Content coming soon.",
   disclaimer: "UNDER NO CIRCUMSTANCES DOES THIS SUPPORT REPLACE MEDICAL ADVICE OR FOLLOW-UP."
 };

--- a/dictionaries/es.ts
+++ b/dictionaries/es.ts
@@ -6,7 +6,7 @@ export const dictionary = {
     home: { title: "San Bao – Shiatsu y Naturopatía", description: "Recupera el equilibrio y la respiración con tratamientos manuales y enfoques naturales." },
     contact: { title: "Contacto – San Bao", description: "Reserva una cita o solicita información. Estamos en Bruselas." },
     services: {
-      shiatsu: { title: "Shiatsu & Qi Nei Zang – San Bao", description: "Digitopresión y trabajo visceral para armonizar la energía (Qi)." },
+        shiatsu: { title: "Shiatsu – San Bao", description: "Digitopresión para armonizar la energía (Qi)." },
       naturopathy: { title: "Naturopatía – San Bao", description: "Acompañamiento natural personalizado para el bienestar integral." },
       infant: { title: "Masaje bebé – San Bao", description: "Contacto suave que favorece la calma, el sueño y un crecimiento armonioso." }
     }
@@ -36,9 +36,9 @@ export const dictionary = {
   },
   contact: { title:"Contacto", name:"Nombre", email:"Email", message:"Mensaje", send:"Enviar", whatsapp:"Escríbenos por WhatsApp" },
   services: {
-    shiatsu: {
-      title: "Shiatsu & Qi Nei Zang",
-      lead: "Digitopresión a lo largo de los meridianos y Qi Nei Zang (trabajo visceral) para liberar tensiones y favorecer el flujo del Qi.",
+      shiatsu: {
+        title: "Shiatsu",
+        lead: "Digitopresión a lo largo de los meridianos para liberar tensiones y favorecer el flujo del Qi.",
       cta: "Reservar ahora"
     },
     naturopathy: {
@@ -52,7 +52,8 @@ export const dictionary = {
       cta: "Reservar ahora"
     }
   },
-  more: "Más",
-  placeholder: "Contenido próximamente.",
+    more: "Más",
+    close: "Cerrar",
+    placeholder: "Contenido próximamente.",
   disclaimer: "EN NINGÚN CASO ESTE ACOMPAÑAMIENTO SUSTITUYE UN CONSEJO / SEGUIMIENTO MÉDICO."
 };

--- a/dictionaries/fr.ts
+++ b/dictionaries/fr.ts
@@ -6,7 +6,7 @@ export const dictionary = {
     home: { title: "San Bao – Shiatsu & Naturopathie", description: "Retrouvez équilibre et respiration grâce aux soins manuels et aux approches naturelles." },
     contact: { title: "Contacts – San Bao", description: "Prenez rendez‑vous ou demandez des informations. Nous sommes à Bruxelles." },
     services: {
-      shiatsu: { title: "Shiatsu & Qi Nei Zang – San Bao", description: "Digitopression et travail viscéral pour harmoniser l’énergie (Qi)." },
+        shiatsu: { title: "Shiatsu – San Bao", description: "Digitopression pour harmoniser l’énergie (Qi)." },
       naturopathy: { title: "Naturopathie – San Bao", description: "Conseils et parcours naturels personnalisés pour le bien‑être global." },
       infant: { title: "Massage bébé – San Bao", description: "Un contact doux qui favorise calme, sommeil et croissance harmonieuse." }
     }
@@ -36,9 +36,9 @@ export const dictionary = {
   },
   contact: { title:"Contacts", name:"Nom", email:"Email", message:"Message", send:"Envoyer", whatsapp:"Écrivez‑nous sur WhatsApp" },
   services: {
-    shiatsu: {
-      title: "Shiatsu & Qi Nei Zang",
-      lead: "Digitopression le long des méridiens et Qi Nei Zang (travail viscéral) pour relâcher les tensions et favoriser la circulation du Qi.",
+      shiatsu: {
+        title: "Shiatsu",
+        lead: "Digitopression le long des méridiens pour relâcher les tensions et favoriser la circulation du Qi.",
       cta: "Prendre rendez‑vous"
     },
     naturopathy: {
@@ -52,7 +52,8 @@ export const dictionary = {
       cta: "Prendre rendez‑vous"
     }
   },
-  more: "Plus",
-  placeholder: "Contenu à venir.",
+    more: "Plus",
+    close: "Fermer",
+    placeholder: "Contenu à venir.",
   disclaimer: "EN AUCUN CAS, CET ACCOMPAGNEMENT NE REMPLACE UN AVIS / SUIVI MEDICAL"
 };

--- a/dictionaries/it.ts
+++ b/dictionaries/it.ts
@@ -6,7 +6,7 @@ export const dictionary = {
     home: { title: "San Bao – Shiatsu & Naturopatia", description: "Ritrova equilibrio e respiro con trattamenti manuali e percorsi naturali." },
     contact: { title: "Contatti – San Bao", description: "Prenota un appuntamento o chiedi informazioni. Siamo a Bruxelles." },
     services: {
-      shiatsu: { title: "Shiatsu & Qi Nei Zang – San Bao", description: "Digitopressione e lavoro viscerale per riequilibrare l’energia (Qi)." },
+        shiatsu: { title: "Shiatsu – San Bao", description: "Digitopressione per riequilibrare l’energia (Qi)." },
       naturopathy: { title: "Naturopatia – San Bao", description: "Consulenze e percorsi naturali personalizzati per il benessere globale." },
       infant: { title: "Massaggio bimbi – San Bao", description: "Contatto dolce che favorisce calma, sonno e crescita armoniosa." }
     }
@@ -36,9 +36,9 @@ export const dictionary = {
   },
   contact: { title:"Contatti", name:"Nome", email:"Email", message:"Messaggio", send:"Invia", whatsapp:"Scrivici su WhatsApp" },
   services: {
-    shiatsu: {
-      title: "Shiatsu & Qi Nei Zang",
-      lead: "Digitopressione lungo i meridiani e Qi Nei Zang (lavoro viscerale) per sciogliere tensioni e favorire il flusso del Qi.",
+      shiatsu: {
+        title: "Shiatsu",
+        lead: "Digitopressione lungo i meridiani per sciogliere tensioni e favorire il flusso del Qi.",
       cta: "Prenota ora"
     },
     naturopathy: {
@@ -52,7 +52,8 @@ export const dictionary = {
       cta: "Prenota ora"
     }
   },
-  more: "Più",
-  placeholder: "Contenuto in arrivo.",
+    more: "Più",
+    close: "Chiudi",
+    placeholder: "Contenuto in arrivo.",
   disclaimer: "IN NESSUN CASO QUESTO ACCOMPAGNAMENTO SOSTITUISCE UN PARERE / SEGUITO MEDICO."
 };

--- a/dictionaries/nl.ts
+++ b/dictionaries/nl.ts
@@ -6,7 +6,7 @@ export const dictionary = {
     home: { title: "San Bao – Shiatsu & Naturopathie", description: "Herstel balans en ademhaling met manuele behandelingen en natuurlijke benaderingen." },
     contact: { title: "Contact – San Bao", description: "Maak een afspraak of vraag informatie. We zijn in Brussel." },
     services: {
-      shiatsu: { title: "Shiatsu & Qi Nei Zang – San Bao", description: "Drukpuntmassage en visceraal werk om de energie (Qi) te harmoniseren." },
+        shiatsu: { title: "Shiatsu – San Bao", description: "Drukpuntmassage om de energie (Qi) te harmoniseren." },
       naturopathy: { title: "Naturopathie – San Bao", description: "Persoonlijk natuurlijk advies voor algemeen welzijn." },
       infant: { title: "Babymassage – San Bao", description: "Zachte aanraking die rust, slaap en harmonieuze groei ondersteunt." }
     }
@@ -36,9 +36,9 @@ export const dictionary = {
   },
   contact: { title:"Contact", name:"Naam", email:"E‑mail", message:"Bericht", send:"Versturen", whatsapp:"Schrijf ons op WhatsApp" },
   services: {
-    shiatsu: {
-      title: "Shiatsu & Qi Nei Zang",
-      lead: "Drukpuntmassage langs de meridianen en Qi Nei Zang (visceraal werk) om spanning los te laten en de stroom van Qi te ondersteunen.",
+      shiatsu: {
+        title: "Shiatsu",
+        lead: "Drukpuntmassage langs de meridianen om spanning los te laten en de stroom van Qi te ondersteunen.",
       cta: "Boek nu"
     },
     naturopathy: {
@@ -52,7 +52,8 @@ export const dictionary = {
       cta: "Boek nu"
     }
   },
-  more: "Meer",
-  placeholder: "Inhoud binnenkort beschikbaar.",
+    more: "Meer",
+    close: "Sluiten",
+    placeholder: "Inhoud binnenkort beschikbaar.",
   disclaimer: "IN GEEN GEVAL VERVANGT DEZE BEGELEIDING EEN MEDISCH ADVIES / OPVOLGING."
 };


### PR DESCRIPTION
## Summary
- add translated close buttons to service overlays
- match Setmore booking button styling to "More" link
- remove Qi Nei Zang references from Shiatsu titles and descriptions

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899f30e6e908330a9d68127217794c0