### PR TITLE
Adjust overlay position and refine homepage logo

### DIFF
--- a/app/[locale]/(site)/page.tsx
+++ b/app/[locale]/(site)/page.tsx
@@ -23,7 +23,7 @@ export default async function Home({ params }: { params: Promise<{ locale: Local
           <img src="/hero-texture.svg" alt="" className="w-full h-full object-cover opacity-30" />
         </div>
         <div className="mx-auto max-w-6xl px-4 py-20 text-center">
-           <img src="/images/Logo-colours.png" alt="San Bao" className="mx-auto h-28 w-auto mb-6" />
+          <img src="/images/Logo-colours_.png" alt="San Bao" className="mx-auto h-28 w-auto mb-6 rounded-full" />
           <h1 className="text-3xl md:text-5xl font-semibold text-ink">{dict.home.heroHeading}</h1>
           <p className="mt-4 text-lg text-slate-700">{dict.home.heroText}</p>
         </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,3 +4,4 @@
 :root{color-scheme:light}
 body{@apply bg-white text-slate-800}
 a{@apply transition}
+body>iframe[src*="setmore"],body>div[id*="setmore"]{top:4rem!important;height:calc(100% - 4rem)!important}


### PR DESCRIPTION
## Summary
- offset Setmore overlays so they don't overlap the sticky header
- show rounded San Bao logo with transparent background on the homepage

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a12d57e848330871746e571e8b405