### PR TITLE
Fix overlay layering on "More" pages

### DIFF
--- a/app/[locale]/(site)/services/face-massage/more/page.tsx
+++ b/app/[locale]/(site)/services/face-massage/more/page.tsx
@@ -6,7 +6,7 @@ export default async function FaceMassageMorePage({ params }: { params: Promise<
   const dict = await getDictionary(locale);
 
   return (
-    <div className="fixed inset-0 bg-white/90 p-8 overflow-y-auto">
+    <div className="fixed inset-0 z-40 bg-white/90 p-8 overflow-y-auto">
       <Link
         href={`/${locale}/services/face-massage`}
         className="absolute top-8 right-8 inline-block px-5 py-3 rounded-xl2 border border-gold text-gold hover:bg-gold hover:text-white transition"

--- a/app/[locale]/(site)/services/infant-massage/more/page.tsx
+++ b/app/[locale]/(site)/services/infant-massage/more/page.tsx
@@ -7,7 +7,7 @@ export default async function InfantMorePage({ params }: { params: Promise<{ loc
   const t = dict.services.infant;
 
   return (
-    <div className="fixed inset-0 bg-white/90 p-8 overflow-y-auto">
+    <div className="fixed inset-0 z-40 bg-white/90 p-8 overflow-y-auto">
       <Link
         href={`/${locale}/services/infant-massage`}
         className="absolute top-8 right-8 inline-block px-5 py-3 rounded-xl2 border border-gold text-gold hover:bg-gold hover:text-white transition"

--- a/app/[locale]/(site)/services/naturopathy/more/page.tsx
+++ b/app/[locale]/(site)/services/naturopathy/more/page.tsx
@@ -7,7 +7,7 @@ export default async function NaturopathyMorePage({ params }: { params: Promise<
   const t = dict.services.naturopathy;
 
   return (
-    <div className="fixed inset-0 bg-white/90 p-8 overflow-y-auto">
+    <div className="fixed inset-0 z-40 bg-white/90 p-8 overflow-y-auto">
       <Link
         href={`/${locale}/services/naturopathy`}
         className="absolute top-8 right-8 inline-block px-5 py-3 rounded-xl2 border border-gold text-gold hover:bg-gold hover:text-white transition"

--- a/app/[locale]/(site)/services/qi-nei-zang/more/page.tsx
+++ b/app/[locale]/(site)/services/qi-nei-zang/more/page.tsx
@@ -6,7 +6,7 @@ export default async function QiNeiZangMorePage({ params }: { params: Promise<{ 
   const dict = await getDictionary(locale);
 
   return (
-    <div className="fixed inset-0 bg-white/90 p-8 overflow-y-auto">
+    <div className="fixed inset-0 z-40 bg-white/90 p-8 overflow-y-auto">
       <Link
         href={`/${locale}/services/qi-nei-zang`}
         className="absolute top-8 right-8 inline-block px-5 py-3 rounded-xl2 border border-gold text-gold hover:bg-gold hover:text-white transition"

--- a/app/[locale]/(site)/services/shiatsu/more/page.tsx
+++ b/app/[locale]/(site)/services/shiatsu/more/page.tsx
@@ -7,7 +7,7 @@ export default async function ShiatsuMorePage({ params }: { params: Promise<{ lo
   const t = dict.services.shiatsu;
 
   return (
-    <div className="fixed inset-0 bg-white/90 p-8 overflow-y-auto">
+    <div className="fixed inset-0 z-40 bg-white/90 p-8 overflow-y-auto">
       <Link
         href={`/${locale}/services/shiatsu`}
         className="absolute top-8 right-8 inline-block px-5 py-3 rounded-xl2 border border-gold text-gold hover:bg-gold hover:text-white transition"


### PR DESCRIPTION
## Summary
- ensure overlays opened via "More" links render above the sticky header

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a159a4a8c83308c28f894005e364f