### PR TITLE
Use dedicated service images on home page

### DIFF
--- a/app/[locale]/(site)/page.tsx
+++ b/app/[locale]/(site)/page.tsx
@@ -33,10 +33,10 @@ export default async function Home({ params }: { params: Promise<{ locale: Local
         <h2 className="text-2xl font-semibold text-ink mb-6">{dict.home.cardsTitle}</h2>
         <div className="grid gap-6 md:grid-cols-3">
           <ServiceCard locale={locale} title={dict.home.cardShiatsu} href="/services/shiatsu" img="/images/shiatsu.webp" />
-          <ServiceCard locale={locale} title={dict.home.cardQiNeiZang} href="/services/qi-nei-zang" img="/images/shiatsu.webp" />
-          <ServiceCard locale={locale} title={dict.home.cardInfant} href="/services/infant-massage" img="/images/infant-massage.webp" />
+          <ServiceCard locale={locale} title={dict.home.cardQiNeiZang} href="/services/qi-nei-zang" img="/images/QiNeiZang.png" />
+          <ServiceCard locale={locale} title={dict.home.cardInfant} href="/services/infant-massage" img="/images/MassageBebe.png" />
           <ServiceCard locale={locale} title={dict.home.cardNaturopathy} href="/services/naturopathy" img="/images/naturopathy.webp" />
-          <ServiceCard locale={locale} title={dict.home.cardFaceMassage} href="/services/face-massage" img="/images/naturopathy.webp" />
+          <ServiceCard locale={locale} title={dict.home.cardFaceMassage} href="/services/face-massage" img="/images/FaceMassage.png" />
           <ServiceCard locale={locale} title={dict.home.cardAboutMe} href="/about" img="/images/contact.webp" />
         </div>
       </section>


### PR DESCRIPTION
## Summary
- Display correct images for Qi Nei Zang, infant massage, and face massage cards on the home page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689a208e77a48330b6dceba5c866a232