### PR TITLE
Add localized face massage overlay content

### DIFF
--- a/app/[locale]/(site)/services/face-massage/more/page.tsx
+++ b/app/[locale]/(site)/services/face-massage/more/page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 export default async function FaceMassageMorePage({ params }: { params: Promise<{ locale: Locale }> }) {
   const { locale } = await params;
   const dict = await getDictionary(locale);
+  const t = dict.services.faceMassage;
 
   return (
     <div className="fixed inset-0 z-40 bg-white/90 p-8 overflow-y-auto">
@@ -14,8 +15,8 @@ export default async function FaceMassageMorePage({ params }: { params: Promise<
         {dict.close}
       </Link>
       <div className="mx-auto max-w-3xl">
-        <h1 className="text-3xl font-semibold text-ink mb-4">{dict.nav.faceMassage}</h1>
-        <p className="text-lg text-slate-700">{dict.placeholder}</p>
+        <h1 className="text-3xl font-semibold text-ink mb-4">{t.title}</h1>
+        <p className="text-lg text-slate-700 whitespace-pre-line">{t.more}</p>
       </div>
     </div>
   );

--- a/dictionaries/en.ts
+++ b/dictionaries/en.ts
@@ -50,6 +50,11 @@ export const dictionary = {
       title: "Infant massage",
       lead: "A gentle touch that fosters calm, sleep and harmonious growth while strengthening the parent‑child bond.",
       cta: "Book now"
+    },
+    faceMassage: {
+      title: "Face massage",
+      cta: "Book now",
+      more: "Kobido-style face massage.\n\nKobido is a Japanese massage that tones the facial muscles, activates microcirculation and has visible effects on the beauty of the skin.\n\nA Kobido session lasts 50 minutes and costs €60. Since the visible effects of Kobido are linked to regular practice, a 6-massage card is priced at €300, giving you one massage free."
     }
   },
     more: "More",

--- a/dictionaries/es.ts
+++ b/dictionaries/es.ts
@@ -50,6 +50,11 @@ export const dictionary = {
       title: "Masaje bebé",
       lead: "Un contacto suave que fomenta la calma, el sueño y un crecimiento armonioso, fortaleciendo el vínculo entre padres e hijos.",
       cta: "Reservar ahora"
+    },
+    faceMassage: {
+      title: "Masaje facial",
+      cta: "Reservar ahora",
+      more: "Masaje facial estilo Kobido.\n\nEl Kobido es un masaje japonés que tonifica los músculos del rostro, activa la microcirculación y tiene efectos visibles en la belleza de la piel facial.\n\nLa sesión de Kobido dura 50 minutos y cuesta 60 €. Dado que los efectos visibles del Kobido están ligados a su práctica regular, el bono de 6 masajes tiene un precio de 300 €, lo que equivale a un masaje gratis."
     }
   },
     more: "Más",

--- a/dictionaries/fr.ts
+++ b/dictionaries/fr.ts
@@ -1,4 +1,3 @@
-
 export const dictionary = {
   meta: {
     siteName: "San Bao – Shiatsu & Naturopathie",
@@ -39,8 +38,8 @@ export const dictionary = {
       shiatsu: {
         title: "Shiatsu",
         lead: "Digitopression le long des méridiens pour relâcher les tensions et favoriser la circulation du Qi.",
-      cta: "Prendre rendez‑vous"
-    },
+        cta: "Prendre rendez‑vous"
+      },
     naturopathy: {
       title: "Naturopathie",
       lead: "Conseils personnalisés: alimentation, mode de vie et techniques douces pour le bien‑être global.",
@@ -50,6 +49,11 @@ export const dictionary = {
       title: "Massage bébé",
       lead: "Un contact doux pour encourager le calme, le sommeil et une croissance harmonieuse, tout en renforçant le lien parent‑enfant.",
       cta: "Prendre rendez‑vous"
+    },
+    faceMassage: {
+      title: "Massage du visage",
+      cta: "Prendre rendez‑vous",
+      more: "massage du visage de style kobido.\n\nLe kobido est un massage japonais qui tonifie les muscles du visage, active la micro-circulation et a des effets visibles sur la beauté de la peau du visage.\n\nLa séance de kobido dure 50 minutes et coûte 60€. Etant donné que les effets visibles du kobido sont liés à sa pratique régulière, la carte de 6 massage est au prix de 300€, soit un massage offert."
     }
   },
     more: "Plus",

--- a/dictionaries/it.ts
+++ b/dictionaries/it.ts
@@ -50,6 +50,11 @@ export const dictionary = {
       title: "Massaggio neonato",
       lead: "Contatto dolce per favorire calma, sonno e crescita armoniosa del bambino e rafforzare il legame genitore‑bimbo.",
       cta: "Prenota ora"
+    },
+    faceMassage: {
+      title: "Massaggio facciale",
+      cta: "Prenota ora",
+      more: "Massaggio facciale in stile Kobido.\n\nIl Kobido è un massaggio giapponese che tonifica i muscoli del viso, attiva la microcircolazione e ha effetti visibili sulla bellezza della pelle del viso.\n\nLa seduta di Kobido dura 50 minuti e costa 60 €. Poiché gli effetti visibili del Kobido sono legati alla sua pratica regolare, il pacchetto di 6 massaggi costa 300 €, ovvero un massaggio in omaggio."
     }
   },
     more: "Più",

--- a/dictionaries/nl.ts
+++ b/dictionaries/nl.ts
@@ -50,6 +50,11 @@ export const dictionary = {
       title: "Babymassage",
       lead: "Zachte aanraking die rust, slaap en een harmonieuze groei bevordert en de band ouder‑kind versterkt.",
       cta: "Boek nu"
+    },
+    faceMassage: {
+      title: "Gezichtsmassage",
+      cta: "Boek nu",
+      more: "Kobido-stijl gezichtsmassage.\n\nKobido is een Japanse massage die de gezichtsspieren verstevigt, de microcirculatie activeert en zichtbare effecten heeft op de schoonheid van de gezichtshuid.\n\nEen Kobido-sessie duurt 50 minuten en kost €60. Omdat de zichtbare effecten van Kobido verbonden zijn aan regelmatige beoefening, kost een kaart van 6 massages €300, wat neerkomt op één massage gratis."
     }
   },
     more: "Meer",


### PR DESCRIPTION
## Summary
- add Kobido-style face massage description in French, English, Spanish, Italian, and Dutch dictionaries
- display localized face massage copy on the More overlay

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689a217b89e08330afe548693e809fbe