### PR TITLE
Remove hero text and enlarge logo on home page

### DIFF
--- a/app/[locale]/(site)/page.tsx
+++ b/app/[locale]/(site)/page.tsx
@@ -23,9 +23,8 @@ export default async function Home({ params }: { params: Promise<{ locale: Local
           <img src="/hero-texture.svg" alt="" className="w-full h-full object-cover opacity-30" />
         </div>
         <div className="mx-auto max-w-6xl px-4 py-20 text-center">
-          <img src="/images/Logo-colours_.png" alt="San Bao" className="mx-auto h-28 w-auto mb-6 rounded-full" />
-          <h1 className="text-3xl md:text-5xl font-semibold text-ink">{dict.home.heroHeading}</h1>
-          <p className="mt-4 text-lg text-slate-700">{dict.home.heroText}</p>
+          <img src="/images/Logo-colours_.png" alt="San Bao" className="mx-auto h-48 w-auto mb-6 rounded-full" />
+          <p className="text-lg text-slate-700">{dict.home.heroText}</p>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- Enlarge home logo for better visual balance
- Remove "San Bao" heading text from hero section

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689a23f4f7488330a615e7e9d0d500e8