### PR TITLE
feat: add naturopathy more page content

### DIFF
--- a/app/[locale]/(site)/services/naturopathy/more/page.tsx
+++ b/app/[locale]/(site)/services/naturopathy/more/page.tsx
@@ -16,7 +16,7 @@ export default async function NaturopathyMorePage({ params }: { params: Promise<
       </Link>
       <div className="mx-auto max-w-3xl">
         <h1 className="text-3xl font-semibold text-ink mb-4">{t.title}</h1>
-        <p className="text-lg text-slate-700">{dict.placeholder}</p>
+        <p className="text-lg text-slate-700 whitespace-pre-line">{t.more}</p>
       </div>
     </div>
   );

--- a/dictionaries/en.ts
+++ b/dictionaries/en.ts
@@ -45,7 +45,8 @@ export const dictionary = {
     naturopathy: {
       title: "Naturopathy",
       lead: "Personalised natural guidance: nutrition, lifestyle and gentle techniques for overall wellbeing.",
-      cta: "Book now"
+      cta: "Book now",
+      more: "\"The microbe is nothing, the biological terrain is everything\".\nThe naturopath is above all a guide who, based on the vitality assessment carried out, proposes a personalised programme of vital hygiene to strengthen the body’s self-healing capacities, detoxify and make up for any deficiencies.\n\nThe vital hygiene programme we will establish together will take into account your family, social and professional environment; your eating and sporting habits; your stress level, the quality of your sleep and your appetite, etc.\n\nThe programme recommends the use of plants, includes detoxifying and remineralising cures but also offers massages (shiatsu/Qi Nei Zang) or hydrotherapy techniques. The first session lasts 1h30 and costs €80, and its aim is to understand your environment, your habits, your lifestyle and your expectations. At the end of this vitality assessment, I prepare a personalised protocol that runs over several weeks. This protocol will provide advice on food and other aspects of daily life (activities, plants, relaxation, etc.)\n\nFollow-up sessions, optional, last 1 hour and cost €65.\n\nWant to know more?\n\nThe naturopath in no way replaces the doctor but accompanies you while taking ongoing medical treatments into account."
     },
     infant: {
       title: "Infant massage",

--- a/dictionaries/es.ts
+++ b/dictionaries/es.ts
@@ -45,7 +45,8 @@ export const dictionary = {
     naturopathy: {
       title: "Naturopatía",
       lead: "Acompañamiento natural personalizado: alimentación, estilo de vida y técnicas suaves para el bienestar integral.",
-      cta: "Reservar ahora"
+      cta: "Reservar ahora",
+      more: "«El microbio no es nada, el terreno biológico lo es todo».\nEl naturópata es ante todo un guía que, basándose en la evaluación de la vitalidad realizada, propone un programa personalizado de higiene vital con el fin de potenciar las capacidades de autocuración de la persona, desintoxicarla y suplir posibles carencias.\n\nEl programa de higiene vital que estableceremos juntos tendrá en cuenta tu entorno familiar, social y profesional; tus hábitos alimentarios y deportivos; tu nivel de estrés, la calidad de tu sueño y tu apetito, etc.\n\nEl programa aconseja el uso de plantas, incluye curas desintoxicantes y remineralizantes, pero también propone masajes (shiatsu/Qi Nei Zang) o técnicas hidroterápicas. La primera sesión dura 1h30 y cuesta 80 €. El objetivo de esta sesión es entender tu entorno, tus hábitos, tu estilo de vida y tus expectativas. Al término de esta evaluación de la vitalidad, te preparo un protocolo personalizado que se desarrolla a lo largo de varias semanas. Este protocolo proporcionará consejos relativos a la alimentación y a otros aspectos de la vida cotidiana (actividad, plantas, relajación, etc.)\n\nLas sesiones de seguimiento, opcionales, duran 1 hora y cuestan 65 €.\n\n¿Quieres saber más?\n\nEl naturópata en ningún caso sustituye al médico; te acompaña teniendo en cuenta los tratamientos médicos en curso."
     },
     infant: {
       title: "Masaje bebé",

--- a/dictionaries/fr.ts
+++ b/dictionaries/fr.ts
@@ -44,7 +44,8 @@ export const dictionary = {
     naturopathy: {
       title: "Naturopathie",
       lead: "Conseils personnalisés: alimentation, mode de vie et techniques douces pour le bien‑être global.",
-      cta: "Prendre rendez‑vous"
+      cta: "Prendre rendez‑vous",
+      more: "« Le microbe n’est rien, le terrain biologique est tout ».\nLe naturopathe est avant tout un guide qui, sur la base de l’évaluation de vitalité réalisée, propose un programme personnalisé d’hygiène vitale afin de renforcer les capacités d’autoguérison de la personne, de la détoxifier et de combler d’éventuelles carences.\n\nLe programme d’hygiène vitale que nous établirons ensemble tiendra compte de votre environnement familial, social et professionnel ; de vos habitudes alimentaires et sportives ; de votre niveau de stress, de la qualité de votre sommeil et de votre appétit, etc.\n\nLe programme conseille l’utilisation des plantes, comprend des cures détoxifiantes et reminéralisantes mais propose aussi des massages (shiatsu/Qi Nei Zang) ou des techniques d’hydrothérapie. La première séance dure 1h30 et coûte 80 €. L’objectif de cette séance est de comprendre votre environnement, vos habitudes, votre mode de vie et vos attentes. À l’issue de cette évaluation de vitalité, je vous prépare un protocole personnalisé qui se déroule sur plusieurs semaines. Ce protocole fournira des conseils relatifs à l’alimentation et à d’autres aspects de la vie quotidienne (activités, plantes, détente, etc.)\n\nLes séances de suivi, facultatives, durent 1 heure et coûtent 65 €.\n\nVous souhaitez en savoir plus ?\n\nLe naturopathe ne se substitue en aucun cas au médecin ; il accompagne en tenant compte des traitements médicaux en cours."
     },
     infant: {
       title: "Massage bébé",

--- a/dictionaries/it.ts
+++ b/dictionaries/it.ts
@@ -45,7 +45,8 @@ export const dictionary = {
     naturopathy: {
       title: "Naturopatia",
       lead: "Consulenze e percorsi naturali personalizzati: alimentazione, stile di vita e tecniche dolci per il benessere globale.",
-      cta: "Prenota ora"
+      cta: "Prenota ora",
+      more: "\"Il microbo non è niente, il terreno biologico è tutto\".\nIl naturopata è soprattutto una guida che, sulla base della valutazione della vitalità effettuata, propone un programma personalizzato di igiene vitale al fine di potenziare le capacità di autoguarigione della persona, disintossicarsi e colmare eventuali carenze.\n\nIl programma di igiene vitale che stabiliremo insieme terrà conto del tuo ambiente familiare, sociale e professionale; delle tue abitudini alimentari e sportive; del tuo stato di stress, della qualità del tuo sonno e del tuo appetito, ecc.\n\nIl programma consiglia l'utilizzo delle piante, comprende cure disintossicanti e rimineralizzanti ma propone anche massaggi (shiatsu/Qi Nei Zang) o tecniche idroterapiche. La prima sessione dura 1h30 e costa 80€, l'obiettivo di questa sessione è capire il tuo ambiente, le tue abitudini, il tuo stile di vita e le tue aspettative. Al termine di questa valutazione della vitalità, ti preparo un protocollo personalizzato che si sviluppa su più settimane. Questo protocollo fornirà consigli relativi al cibo e ad altri aspetti della vita quotidiana (attività, piante, relax, ecc.)\n\nLe sessioni di follow-up, facoltative, durano 1 ora e costano € 65.\n\nVuoi saperne di più?\n\nIl naturopata non si sostituisce in alcun modo al medico, lo accompagna tenendo conto delle cure mediche in atto."
     },
     infant: {
       title: "Massaggio neonato",

--- a/dictionaries/nl.ts
+++ b/dictionaries/nl.ts
@@ -45,7 +45,8 @@ export const dictionary = {
     naturopathy: {
       title: "Naturopathie",
       lead: "Persoonlijk natuurlijk advies: voeding, levensstijl en zachte technieken voor algemeen welzijn.",
-      cta: "Boek nu"
+      cta: "Boek nu",
+      more: "\"Het microbe is niets, het biologische terrein is alles\".\nDe naturopaat is vooral een gids die, op basis van de uitgevoerde vitaliteitsbeoordeling, een gepersonaliseerd programma van vitale hygiëne voorstelt om de zelfgenezende vermogens van het lichaam te versterken, te ontgiften en eventuele tekorten aan te vullen.\n\nHet vitale hygiëneprogramma dat we samen zullen opstellen houdt rekening met je familiale, sociale en professionele omgeving; je eet- en sportgewoonten; je stressniveau, de kwaliteit van je slaap en je eetlust, enz.\n\nHet programma raadt het gebruik van planten aan, omvat ontgiftende en remineraliserende kuren maar stelt ook massages (shiatsu/Qi Nei Zang) of hydrotherapische technieken voor. De eerste sessie duurt 1u30 en kost €80. Het doel van deze sessie is je omgeving, je gewoonten, je levensstijl en je verwachtingen te begrijpen. Na deze vitaliteitsbeoordeling stel ik een gepersonaliseerd protocol op dat zich over meerdere weken uitstrekt. Dit protocol geeft advies over voeding en andere aspecten van het dagelijks leven (activiteiten, planten, ontspanning, enz.)\n\nVervolgsessies, optioneel, duren 1 uur en kosten €65.\n\nWil je meer weten?\n\nDe naturopaat vervangt de arts in geen geval; hij begeleidt je met inachtneming van de lopende medische behandelingen."
     },
     infant: {
       title: "Babymassage",


### PR DESCRIPTION
## Summary
- add detailed Naturopathy content and translations for the “More” overlay
- render Naturopathy overlay text

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689b72c8b87483309f9cfbaf327c038b