### PR TITLE
feat: add face massage lead and translations

### DIFF
--- a/app/[locale]/(site)/services/face-massage/page.tsx
+++ b/app/[locale]/(site)/services/face-massage/page.tsx
@@ -5,15 +5,15 @@ import Link from "next/link";
 export default async function FaceMassagePage({ params }: { params: Promise<{ locale: Locale }> }) {
   const { locale } = await params;
   const dict = await getDictionary(locale);
-  const cta = dict.services.naturopathy.cta;
+  const t = dict.services.faceMassage;
   return (
     <article className="mx-auto max-w-6xl px-4 py-12">
       <header className="grid md:grid-cols-2 gap-8 items-center">
         <div>
-          <h1 className="text-3xl font-semibold text-ink">{dict.nav.faceMassage}</h1>
-          <p className="mt-4 text-lg text-slate-700">{dict.placeholder}</p>
+          <h1 className="text-3xl font-semibold text-ink">{t.title}</h1>
+          <p className="mt-4 text-lg text-slate-700">{t.lead}</p>
           <div className="mt-8 flex gap-4">
-            <SetmoreButton alt={cta} />
+            <SetmoreButton alt={t.cta} />
             <Link
               href={`/${locale}/services/face-massage/more`}
               className="inline-block px-5 py-3 rounded-xl2 border border-gold text-gold hover:bg-gold hover:text-white transition"

--- a/dictionaries/en.ts
+++ b/dictionaries/en.ts
@@ -54,6 +54,7 @@ export const dictionary = {
     },
     faceMassage: {
       title: "Face massage",
+      lead: "Discover the glow of a 50-minute Kobido face massage that tones facial muscles, boosts microcirculation and reveals radiant skin.",
       cta: "Book now",
       more: "Kobido-style face massage.\n\nKobido is a Japanese massage that tones the facial muscles, activates microcirculation and has visible effects on the beauty of the skin.\n\nA Kobido session lasts 50 minutes and costs €60. Since the visible effects of Kobido are linked to regular practice, a 6-massage card is priced at €300, giving you one massage free."
     }

--- a/dictionaries/es.ts
+++ b/dictionaries/es.ts
@@ -54,6 +54,7 @@ export const dictionary = {
     },
     faceMassage: {
       title: "Masaje facial",
+      lead: "Descubre el resplandor de un masaje facial Kobido de 50 minutos que tonifica los músculos, activa la microcirculación y revela una piel radiante.",
       cta: "Reservar ahora",
       more: "Masaje facial estilo Kobido.\n\nEl Kobido es un masaje japonés que tonifica los músculos del rostro, activa la microcirculación y tiene efectos visibles en la belleza de la piel facial.\n\nLa sesión de Kobido dura 50 minutos y cuesta 60 €. Dado que los efectos visibles del Kobido están ligados a su práctica regular, el bono de 6 masajes tiene un precio de 300 €, lo que equivale a un masaje gratis."
     }

--- a/dictionaries/fr.ts
+++ b/dictionaries/fr.ts
@@ -53,6 +53,7 @@ export const dictionary = {
     },
     faceMassage: {
       title: "Massage du visage",
+      lead: "Découvrez l'éclat d'un massage visage Kobido de 50 minutes qui tonifie les muscles, stimule la microcirculation et révèle une peau rayonnante.",
       cta: "Prendre rendez‑vous",
       more: "massage du visage de style kobido.\n\nLe kobido est un massage japonais qui tonifie les muscles du visage, active la micro-circulation et a des effets visibles sur la beauté de la peau du visage.\n\nLa séance de kobido dure 50 minutes et coûte 60€. Etant donné que les effets visibles du kobido sont liés à sa pratique régulière, la carte de 6 massage est au prix de 300€, soit un massage offert."
     }

--- a/dictionaries/it.ts
+++ b/dictionaries/it.ts
@@ -54,6 +54,7 @@ export const dictionary = {
     },
     faceMassage: {
       title: "Massaggio facciale",
+      lead: "Scopri la luminosità di un massaggio facciale Kobido da 50 minuti che tonifica i muscoli, stimola la microcircolazione e rivela una pelle radiosa.",
       cta: "Prenota ora",
       more: "Massaggio facciale in stile Kobido.\n\nIl Kobido è un massaggio giapponese che tonifica i muscoli del viso, attiva la microcircolazione e ha effetti visibili sulla bellezza della pelle del viso.\n\nLa seduta di Kobido dura 50 minuti e costa 60 €. Poiché gli effetti visibili del Kobido sono legati alla sua pratica regolare, il pacchetto di 6 massaggi costa 300 €, ovvero un massaggio in omaggio."
     }

--- a/dictionaries/nl.ts
+++ b/dictionaries/nl.ts
@@ -54,6 +54,7 @@ export const dictionary = {
     },
     faceMassage: {
       title: "Gezichtsmassage",
+      lead: "Ontdek de gloed van een Kobido-gezichtsmassage van 50 minuten die de spieren verstevigt, de microcirculatie stimuleert en een stralende huid onthult.",
       cta: "Boek nu",
       more: "Kobido-stijl gezichtsmassage.\n\nKobido is een Japanse massage die de gezichtsspieren verstevigt, de microcirculatie activeert en zichtbare effecten heeft op de schoonheid van de gezichtshuid.\n\nEen Kobido-sessie duurt 50 minuten en kost €60. Omdat de zichtbare effecten van Kobido verbonden zijn aan regelmatige beoefening, kost een kaart van 6 massages €300, wat neerkomt op één massage gratis."
     }


### PR DESCRIPTION
## Summary
- display a descriptive lead on the face massage page
- translate the Kobido face massage tagline into en, fr, it, es, and nl

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b7347d8388330980ef1566a661ed8