### PR TITLE
feat: add about page content and translations

### DIFF
--- a/app/[locale]/(site)/about/page.tsx
+++ b/app/[locale]/(site)/about/page.tsx
@@ -8,7 +8,9 @@ export default async function AboutPage({ params }: { params: Promise<{ locale: 
       <header className="grid md:grid-cols-2 gap-8 items-center">
         <div>
           <h1 className="text-3xl font-semibold text-ink">{dict.nav.about}</h1>
-          <p className="mt-4 text-lg text-slate-700">{dict.placeholder}</p>
+          <div className="mt-4 text-lg text-slate-700 whitespace-pre-line">
+            {dict.about.content}
+          </div>
         </div>
         <div className="rounded-2xl overflow-hidden border shadow-soft">
           <img src="/images/contact.webp" alt="" className="w-full h-full object-cover" />

--- a/dictionaries/en.ts
+++ b/dictionaries/en.ts
@@ -35,6 +35,31 @@ export const dictionary = {
     contactLead:"Questions? Get in touch",
     contactBtn:"Contact"
   },
+  about: {
+    content: `I founded San Bao because I believe in a personalised approach to your well-being, as each individual is unique. The name "San Bao" symbolises the "three treasures": body, energy and spirit. My mission is to support you on the path to harmony.
+
+Your guide to holistic well-being.
+Passionate about therapeutic touch, I have been developing my skills through various trainings since 2010:
+
+• Shiatsu and Qi Nei Zang:
+   - well-being shiatsu (Masunaga) with Philippe Vandenabeele – Shinzuikai for 2 years.
+   - therapeutic shiatsu with Ivan Bel – EBST – (whom I also assisted for a year after my training) and Philippe Banai (Ryoho Shiatsu – www.ryohoshiatsu.com) for 4 years.
+   - specialisation in Qi Nei Zang (or Chi Nei Tsang, "organ massage" – www.idoschool.be)
+
+• Reiki and Touch for Health (International Reiki Centre and www.ressourcetoit.be).
+
+• Herbalism (with Anysia Ducastel) and naturopathy (Phytocorsa and E.N.S.A. European Naturopathic School Association)
+
+• Geobiology: training with Alain de Luzan – Geobios – in 2019; taking the environment into account for complete well-being.
+
+• Several workshops help deepen my knowledge, among others: Swedish massage training in 2010, TCM courses with Raphael Piotto in 2015, therapeutic and fluidic shiatsu with Bernard Bouheret, family Thai Gua Sha course with Gilles Thuriaux in 2019, bioenergy at the Résonnances Vivantes centre, palpatory anatomy (EEM), Seiki with Frans Copers (2022) and various introductions to hand and foot reflexology.
+
+Become the actor of your own balance.
+These different universes allow me to offer you comprehensive and personalised support based on bodywork, lifestyle advice and attentive listening, going beyond occasional treatments to help you take charge of your well-being, whether to relieve stress, pain or simply to take care of yourself. Of course, all advice is given with the agreement of your doctor and respecting any ongoing medical treatments. I do not replace a doctor under any circumstances.
+
+Looking forward to meeting you!
+Christel`
+  },
   contact: { title:"Contact", name:"Name", email:"Email", message:"Message", send:"Send", whatsapp:"Message us on WhatsApp" },
   services: {
       shiatsu: {

--- a/dictionaries/es.ts
+++ b/dictionaries/es.ts
@@ -35,6 +35,31 @@ export const dictionary = {
     contactLead:"¿Tienes preguntas? Contáctanos",
     contactBtn:"Contacto"
   },
+  about: {
+    content: `Fundé San Bao porque creo en un enfoque personalizado para tu bienestar, ya que cada individuo es único. El nombre "San Bao" simboliza los "tres tesoros": el cuerpo, la energía y el espíritu. Mi misión es acompañarte en el camino hacia la armonía.
+
+Tu guía hacia el bienestar holístico.
+Apasionada por el toque terapéutico, desarrollo mis competencias a través de múltiples formaciones desde 2010:
+
+• Shiatsu y Qi Nei Zang:
+   - shiatsu de bienestar (Masunaga) con Philippe Vandenabeele – Shinzuikai durante 2 años.
+   - shiatsu terapéutico con Ivan Bel – EBST – (a quien también asistí durante un año al finalizar mi formación) y Philippe Banai (Ryoho Shiatsu – www.ryohoshiatsu.com) durante 4 años.
+   - especialización en Qi Nei Zang (o Chi Nei Tsang, «masaje de los órganos» – www.idoschool.be)
+
+• Reiki y Touch for Health (Centro Internacional de Reiki y www.ressourcetoit.be).
+
+• Herbolaria (con Anysia Ducastel) y naturopatía (Phytocorsa y E.N.S.A. European Naturopathic School Association)
+
+• Geobiología: formación con Alain de Luzan – Geobios – en 2019; tener en cuenta el entorno para un bienestar completo.
+
+• Diversos cursos ayudan a profundizar mis conocimientos, entre ellos: formación en masaje sueco en 2010, cursos de MTC de Raphael Piotto seguidos en 2015, shiatsu terapéutico y shiatsu fluídico con Bernard Bouheret, cursos de Gua Sha Thai familiar con Gilles Thuriaux en 2019, bioenergía en el centro Résonnances Vivantes, anatomía palpatoria (EEM), Seiki con Frans Copers (2022) y diversas iniciaciones a la reflexología de manos y pies.
+
+Conviértete en el actor de tu propio equilibrio.
+Estos universos diferentes me permiten ofrecerte un acompañamiento global y personalizado basado en el trabajo corporal, los consejos de higiene de vida y una escucha atenta, que va más allá de cuidados puntuales y te permitirá tomar las riendas de tu bienestar, ya sea para aliviar el estrés, los dolores o simplemente para cuidarte. Por supuesto, todos los consejos se dan con el acuerdo de tu médico y respetando los tratamientos médicos en curso. En ningún caso me sustituyo al médico.
+
+¡Espero conocerte pronto!
+Christel`
+  },
   contact: { title:"Contacto", name:"Nombre", email:"Email", message:"Mensaje", send:"Enviar", whatsapp:"Escríbenos por WhatsApp" },
   services: {
       shiatsu: {

--- a/dictionaries/fr.ts
+++ b/dictionaries/fr.ts
@@ -34,6 +34,31 @@ export const dictionary = {
     contactLead:"Des questions ? Contactez‑nous",
     contactBtn:"Contacts"
   },
+  about: {
+    content: `J'ai fondé San Bao, parce que je crois en une approche personnalisée pour votre bien-être, car chaque individu est unique. Le nom "San Bao" symbolise les "trois trésors" : le corps, l'énergie et l'esprit. Ma mission est de vous accompagner sur le chemin de l'harmonie.
+
+Votre guide vers le bien-être holistique.
+Passionnée par le toucher thérapeutique, je développe mes compétences à travers de multiples formations depuis 2010:
+
+• Shiatsu et Qi Nei Zang :
+   - shiatsu de bien-être (Masunaga) avec Philippe Vandenabeele - Shinzuikai pendant 2 ans.
+   -  shiatsu thérapeutique auprès d'Ivan Bel - EBST - (que j'ai également assisté un an à l'issue de ma formation) et de Philippe Banai (Ryoho Shiatsu - www.ryohoshiatsu.com) pendant 4 ans.
+   -  spécialisation en Qi Nei Zang (ou Chi Nei Tsang, "massage des organes" - www.idoschool.be)
+
+• Reiki et Touch for Health (Centre international de Reiki et www.ressourcetoit.be).
+
+• Herboristerie (auprès d'Anysia Ducastel) et naturopathie : (Phytocorsa et E.N.S.A. European Naturopathic School Association)
+
+• Géobiologie : formation d'Alain de Luzan - Geobios - en 2019; prendre en compte l'environnement pour un bien-être complet.
+
+• Plusieurs stages contribuent à approfondir mes connaissances, comme, entre autres : la formation de massage suédois en 2010, les cours de MTC de Raphael Piotto suivis en 2015, le shiatsu thérapeutique et shiatsu fluidique avec Bernard Bouheret, les cours de Gua Sha Thai familial suivi auprès de Gilles Thuriaux en 2019, la bioénergie au centre Résonnances Vivantes, l'anatomie palpatoire (EEM), le Seiki avec Frans Copers (2022) ou encore différentes initiations de réflexologie palmaire et plantaire.
+
+Devenez l'acteur de votre propre équilibre.
+Ces différents univers me permettent de vous offir un accompagnement global et personnalisé qui se base sur le travail corporel, les conseils en hygiène de vie, et une écoute attentive, qui va au-delà de soins ponctuels et qui vous permettra de prendre en main votre bien-être, que ce soit pour soulager le stress, les douleurs, ou simplement pour prendre soin de vous. Bien évidemment, tous les conseils prodigués se font avec l'accord de votre médecin traitant et en respectant les éventuels traitements médicaux en cours. En aucun cas, je ne me substitue à un médecin.
+
+Au plaisir de vous rencontrer!
+Christel`
+  },
   contact: { title:"Contacts", name:"Nom", email:"Email", message:"Message", send:"Envoyer", whatsapp:"Écrivez‑nous sur WhatsApp" },
   services: {
       shiatsu: {

--- a/dictionaries/it.ts
+++ b/dictionaries/it.ts
@@ -35,6 +35,31 @@ export const dictionary = {
     contactLead:"Hai domande? Contattaci",
     contactBtn:"Contatti"
   },
+  about: {
+    content: `Ho fondato San Bao perché credo in un approccio personalizzato al tuo benessere, poiché ogni individuo è unico. Il nome "San Bao" simboleggia i "tre tesori": corpo, energia e spirito. La mia missione è accompagnarti sul cammino dell'armonia.
+
+Il tuo riferimento per il benessere olistico.
+Appassionata al contatto terapeutico, sviluppo le mie competenze attraverso molteplici formazioni dal 2010:
+
+• Shiatsu e Qi Nei Zang:
+   - shiatsu di benessere (Masunaga) con Philippe Vandenabeele – Shinzuikai per 2 anni.
+   - shiatsu terapeutico con Ivan Bel – EBST – (che ho anche assistito per un anno al termine della formazione) e Philippe Banai (Ryoho Shiatsu – www.ryohoshiatsu.com) per 4 anni.
+   - specializzazione in Qi Nei Zang (o Chi Nei Tsang, «massaggio degli organi» – www.idoschool.be)
+
+• Reiki e Touch for Health (Centro internazionale di Reiki e www.ressourcetoit.be).
+
+• Erboristeria (con Anysia Ducastel) e naturopatia (Phytocorsa e E.N.S.A. European Naturopathic School Association)
+
+• Geobiologia: formazione con Alain de Luzan – Geobios – nel 2019; considerare l'ambiente per un benessere completo.
+
+• Diversi stage contribuiscono ad approfondire le mie conoscenze, tra cui: la formazione in massaggio svedese nel 2010, i corsi di MTC con Raphael Piotto seguiti nel 2015, lo shiatsu terapeutico e fluidico con Bernard Bouheret, i corsi di Gua Sha Thai familiare con Gilles Thuriaux nel 2019, la bioenergia presso il centro Résonnances Vivantes, l’anatomia palpatoria (EEM), il Seiki con Frans Copers (2022) e varie iniziazioni alla reflessologia palmare e plantare.
+
+Diventa protagonista del tuo equilibrio.
+Questi diversi universi mi permettono di offrirti un accompagnamento globale e personalizzato che si basa sul lavoro corporeo, i consigli di igiene di vita e un ascolto attento, andando oltre le cure occasionali e permettendoti di prendere in mano il tuo benessere, che sia per alleviare stress, dolori o semplicemente per prenderti cura di te. Naturalmente, tutti i consigli vengono forniti con l’accordo del tuo medico curante e nel rispetto di eventuali trattamenti in corso. In nessun caso mi sostituisco a un medico.
+
+Piacere di incontrarti!
+Christel`
+  },
   contact: { title:"Contatti", name:"Nome", email:"Email", message:"Messaggio", send:"Invia", whatsapp:"Scrivici su WhatsApp" },
   services: {
       shiatsu: {

--- a/dictionaries/nl.ts
+++ b/dictionaries/nl.ts
@@ -35,6 +35,31 @@ export const dictionary = {
     contactLead:"Vragen? Neem contact op",
     contactBtn:"Contact"
   },
+  about: {
+    content: `Ik heb San Bao opgericht omdat ik geloof in een gepersonaliseerde benadering van jouw welzijn, want ieder mens is uniek. De naam "San Bao" staat voor de "drie schatten": lichaam, energie en geest. Mijn missie is jou te begeleiden op de weg naar harmonie.
+
+Jouw gids naar holistisch welzijn.
+Gepassioneerd door therapeutische aanraking ontwikkel ik sinds 2010 mijn vaardigheden via talrijke opleidingen:
+
+• Shiatsu en Qi Nei Zang:
+   - welzijnsshiatsu (Masunaga) met Philippe Vandenabeele – Shinzuikai gedurende 2 jaar.
+   - therapeutische shiatsu bij Ivan Bel – EBST – (die ik na mijn opleiding ook een jaar assisteerde) en Philippe Banai (Ryoho Shiatsu – www.ryohoshiatsu.com) gedurende 4 jaar.
+   - specialisatie in Qi Nei Zang (of Chi Nei Tsang, "orgaanmassage" – www.idoschool.be)
+
+• Reiki en Touch for Health (Internationaal Reikicentrum en www.ressourcetoit.be).
+
+• Kruidenkunde (bij Anysia Ducastel) en naturopathie (Phytocorsa en E.N.S.A. European Naturopathic School Association)
+
+• Geobiologie: opleiding bij Alain de Luzan – Geobios – in 2019; rekening houden met de omgeving voor volledig welzijn.
+
+• Verschillende stages verdiepen mijn kennis, zoals onder andere: de opleiding Zweedse massage in 2010, de lessen TCM van Raphael Piotto gevolgd in 2015, therapeutische en vloeibare shiatsu met Bernard Bouheret, de opleiding familie Thai Gua Sha bij Gilles Thuriaux in 2019, bio-energie in het centrum Résonnances Vivantes, palpatoire anatomie (EEM), Seiki met Frans Copers (2022) en diverse initiaties in hand- en voetreflexologie.
+
+Word de actor van je eigen evenwicht.
+Deze verschillende werelden stellen mij in staat je een globale en persoonlijke begeleiding te bieden, gebaseerd op lichaamswerk, levenshygiëne en aandachtig luisteren, die verder gaat dan eenmalige behandelingen en je in staat stelt je welzijn in handen te nemen, of het nu is om stress, pijn te verlichten of gewoon om voor jezelf te zorgen. Uiteraard worden alle adviezen gegeven in overleg met je behandelende arts en met respect voor eventuele lopende medische behandelingen. Ik neem in geen geval de plaats van een arts in.
+
+Ik kijk ernaar uit je te ontmoeten!
+Christel`
+  },
   contact: { title:"Contact", name:"Naam", email:"E‑mail", message:"Bericht", send:"Versturen", whatsapp:"Schrijf ons op WhatsApp" },
   services: {
       shiatsu: {


### PR DESCRIPTION
## Summary
- add full about page content and translations for FR, EN, IT, NL, ES
- render translated about text on About page

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b762c7654833096920b75bf742c64