### PR TITLE
feat: add expandable about page

### DIFF
--- a/app/[locale]/(site)/about/more/page.tsx
+++ b/app/[locale]/(site)/about/more/page.tsx
@@ -1,0 +1,23 @@
+import { getDictionary, type Locale } from "@/dictionaries";
+import Link from "next/link";
+
+export default async function AboutMorePage({ params }: { params: Promise<{ locale: Locale }> }) {
+  const { locale } = await params;
+  const dict = await getDictionary(locale);
+  const t = dict.about;
+  return (
+    <div className="fixed inset-0 z-40 bg-white/90 p-8 overflow-y-auto">
+      <Link
+        href={`/${locale}/about`}
+        className="absolute top-8 right-8 inline-block px-5 py-3 rounded-xl2 border border-gold text-gold hover:bg-gold hover:text-white transition"
+      >
+        {dict.close}
+      </Link>
+      <div className="mx-auto max-w-3xl">
+        <h1 className="text-3xl font-semibold text-ink mb-4">{dict.nav.about}</h1>
+        <p className="text-lg text-slate-700 whitespace-pre-line">{t.more}</p>
+      </div>
+    </div>
+  );
+}
+

--- a/app/[locale]/(site)/about/page.tsx
+++ b/app/[locale]/(site)/about/page.tsx
@@ -1,15 +1,23 @@
 import { getDictionary, type Locale } from "@/dictionaries";
+import Link from "next/link";
 
 export default async function AboutPage({ params }: { params: Promise<{ locale: Locale }> }) {
   const { locale } = await params;
   const dict = await getDictionary(locale);
+  const t = dict.about;
   return (
     <article className="mx-auto max-w-6xl px-4 py-12">
       <header className="grid md:grid-cols-2 gap-8 items-center">
         <div>
           <h1 className="text-3xl font-semibold text-ink">{dict.nav.about}</h1>
-          <div className="mt-4 text-lg text-slate-700 whitespace-pre-line">
-            {dict.about.content}
+          <div className="mt-4 text-lg text-slate-700 whitespace-pre-line">{t.content}</div>
+          <div className="mt-8">
+            <Link
+              href={`/${locale}/about/more`}
+              className="inline-block px-5 py-3 rounded-xl2 border border-gold text-gold hover:bg-gold hover:text-white transition"
+            >
+              {dict.more}
+            </Link>
           </div>
         </div>
         <div className="rounded-2xl overflow-hidden border shadow-soft">

--- a/dictionaries/en.ts
+++ b/dictionaries/en.ts
@@ -36,7 +36,12 @@ export const dictionary = {
     contactBtn:"Contact"
   },
   about: {
-    content: `I founded San Bao because I believe in a personalised approach to your well-being, as each individual is unique. The name "San Bao" symbolises the "three treasures": body, energy and spirit. My mission is to support you on the path to harmony.
+    content: `San Bao is built on a personalised approach to wellbeing, inspired by the "three treasures": body, energy and spirit. My aim is to accompany you towards harmony with attentive and tailor-made guidance.
+
+Since 2010 I have explored many therapeutic disciplines: Shiatsu and Qi Nei Zang, Reiki and Touch for Health, herbalism and naturopathy, geobiology and numerous workshops that deepen my understanding of the body and its energies.
+
+These experiences let me offer holistic support that combines bodywork, lifestyle advice and careful listening so you can become the actor of your own balance. I look forward to meeting you.`,
+    more: `I founded San Bao because I believe in a personalised approach to your well-being, as each individual is unique. The name "San Bao" symbolises the "three treasures": body, energy and spirit. My mission is to support you on the path to harmony.
 
 Your guide to holistic well-being.
 Passionate about therapeutic touch, I have been developing my skills through various trainings since 2010:

--- a/dictionaries/es.ts
+++ b/dictionaries/es.ts
@@ -36,7 +36,12 @@ export const dictionary = {
     contactBtn:"Contacto"
   },
   about: {
-    content: `Fundé San Bao porque creo en un enfoque personalizado para tu bienestar, ya que cada individuo es único. El nombre "San Bao" simboliza los "tres tesoros": el cuerpo, la energía y el espíritu. Mi misión es acompañarte en el camino hacia la armonía.
+    content: `San Bao se basa en un enfoque personalizado del bienestar, inspirado en los "tres tesoros": cuerpo, energía y espíritu. Mi objetivo es acompañarte hacia la armonía con una orientación atenta y a medida.
+
+Desde 2010 he explorado numerosas disciplinas terapéuticas: Shiatsu y Qi Nei Zang, Reiki y Touch for Health, herbolaria y naturopatía, geobiología y diversos talleres que profundizan mi comprensión del cuerpo y sus energías.
+
+Estas experiencias me permiten ofrecer un apoyo holístico que combina trabajo corporal, consejos de higiene de vida y una escucha cuidadosa para que te conviertas en el actor de tu propio equilibrio. ¡Espero conocerte pronto!`,
+    more: `Fundé San Bao porque creo en un enfoque personalizado para tu bienestar, ya que cada individuo es único. El nombre "San Bao" simboliza los "tres tesoros": el cuerpo, la energía y el espíritu. Mi misión es acompañarte en el camino hacia la armonía.
 
 Tu guía hacia el bienestar holístico.
 Apasionada por el toque terapéutico, desarrollo mis competencias a través de múltiples formaciones desde 2010:

--- a/dictionaries/fr.ts
+++ b/dictionaries/fr.ts
@@ -35,7 +35,12 @@ export const dictionary = {
     contactBtn:"Contacts"
   },
   about: {
-    content: `J'ai fondé San Bao, parce que je crois en une approche personnalisée pour votre bien-être, car chaque individu est unique. Le nom "San Bao" symbolise les "trois trésors" : le corps, l'énergie et l'esprit. Ma mission est de vous accompagner sur le chemin de l'harmonie.
+    content: `San Bao repose sur une approche personnalisée du bien‑être, inspirée des « trois trésors » : le corps, l'énergie et l'esprit. Mon objectif est de vous accompagner vers l'harmonie avec une écoute attentive et un accompagnement sur mesure.
+
+Depuis 2010, j'explore de nombreuses disciplines thérapeutiques : shiatsu et Qi Nei Zang, Reiki et Touch for Health, herboristerie et naturopathie, géobiologie et divers ateliers qui approfondissent ma compréhension du corps et de ses énergies.
+
+Ces expériences me permettent de proposer un accompagnement holistique mêlant travail corporel, conseils d'hygiène de vie et écoute attentive, afin que vous deveniez acteur de votre propre équilibre. Au plaisir de vous rencontrer !`,
+    more: `J'ai fondé San Bao, parce que je crois en une approche personnalisée pour votre bien-être, car chaque individu est unique. Le nom "San Bao" symbolise les "trois trésors" : le corps, l'énergie et l'esprit. Ma mission est de vous accompagner sur le chemin de l'harmonie.
 
 Votre guide vers le bien-être holistique.
 Passionnée par le toucher thérapeutique, je développe mes compétences à travers de multiples formations depuis 2010:

--- a/dictionaries/it.ts
+++ b/dictionaries/it.ts
@@ -36,7 +36,12 @@ export const dictionary = {
     contactBtn:"Contatti"
   },
   about: {
-    content: `Ho fondato San Bao perché credo in un approccio personalizzato al tuo benessere, poiché ogni individuo è unico. Il nome "San Bao" simboleggia i "tre tesori": corpo, energia e spirito. La mia missione è accompagnarti sul cammino dell'armonia.
+    content: `San Bao nasce da un approccio personalizzato al benessere, ispirato ai "tre tesori": corpo, energia e spirito. La mia missione è accompagnarti verso l'armonia con un sostegno attento e su misura.
+
+Dal 2010 esploro molte discipline terapeutiche: Shiatsu e Qi Nei Zang, Reiki e Touch for Health, erboristeria e naturopatia, geobiologia e numerosi stage che approfondiscono la mia comprensione del corpo e delle sue energie.
+
+Queste esperienze mi permettono di offrire un supporto olistico che unisce lavoro corporeo, consigli sullo stile di vita e un ascolto attento, affinché tu diventi l'attore del tuo equilibrio. Non vedo l'ora di incontrarti!`,
+    more: `Ho fondato San Bao perché credo in un approccio personalizzato al tuo benessere, poiché ogni individuo è unico. Il nome "San Bao" simboleggia i "tre tesori": corpo, energia e spirito. La mia missione è accompagnarti sul cammino dell'armonia.
 
 Il tuo riferimento per il benessere olistico.
 Appassionata al contatto terapeutico, sviluppo le mie competenze attraverso molteplici formazioni dal 2010:

--- a/dictionaries/nl.ts
+++ b/dictionaries/nl.ts
@@ -36,7 +36,12 @@ export const dictionary = {
     contactBtn:"Contact"
   },
   about: {
-    content: `Ik heb San Bao opgericht omdat ik geloof in een gepersonaliseerde benadering van jouw welzijn, want ieder mens is uniek. De naam "San Bao" staat voor de "drie schatten": lichaam, energie en geest. Mijn missie is jou te begeleiden op de weg naar harmonie.
+    content: `San Bao is gebaseerd op een persoonlijke benadering van welzijn, geïnspireerd door de "drie schatten": lichaam, energie en geest. Mijn doel is je met aandacht en maatwerk naar harmonie te begeleiden.
+
+Sinds 2010 verdiep ik me in uiteenlopende therapeutische disciplines: Shiatsu en Qi Nei Zang, Reiki en Touch for Health, kruidengeneeskunde en naturopathie, geobiologie en talloze workshops die mijn begrip van het lichaam en zijn energieën vergroten.
+
+Deze ervaringen stellen mij in staat een holistische begeleiding te bieden die lichaamswerk, leefstijladvies en een luisterend oor combineert, zodat jij de regisseur wordt van je eigen balans. Ik kijk ernaar uit je te ontmoeten.`,
+    more: `Ik heb San Bao opgericht omdat ik geloof in een gepersonaliseerde benadering van jouw welzijn, want ieder mens is uniek. De naam "San Bao" staat voor de "drie schatten": lichaam, energie en geest. Mijn missie is jou te begeleiden op de weg naar harmonie.
 
 Jouw gids naar holistisch welzijn.
 Gepassioneerd door therapeutische aanraking ontwikkel ik sinds 2010 mijn vaardigheden via talrijke opleidingen:


### PR DESCRIPTION
## Summary
- replace About page text with three-paragraph summary and link to full biography
- add modal-like overlay to show complete “About me” text
- extend locale dictionaries with summary and full text entries

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b7a6cfa8883309758548cd3bdaa98